### PR TITLE
Switch to using reusable workflows (in example)

### DIFF
--- a/.github/workflows/example_triggered.yml
+++ b/.github/workflows/example_triggered.yml
@@ -1,6 +1,6 @@
 name: Triggered Workflow
 on:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   rc-test:

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  check-rc:
+  check_rc:
     runs-on: ubuntu-latest
     name: "Check for an OpenMM RC"
     steps:
@@ -30,5 +30,8 @@ jobs:
           ndays: 30
           labels: 'main openmm_rc'
       - run: echo ${{ steps.check.outputs.hasrc }}
-      - uses: ./.github/workflows/example_triggered.yml
-        if: ${{ steps.check.outputs.hasrc == 'True' }}
+  run_rc_tests:
+    runs-on: ubuntu-latest
+    needs: check-rc
+    uses: ./.github/workflows/example_triggered.yml
+    if: ${{ jobs.check_rc.steps.check.outputs.hasrc == 'True' }}

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -31,7 +31,6 @@ jobs:
           labels: 'main openmm_rc'
       - run: echo ${{ steps.check.outputs.hasrc }}
   run_rc_tests:
-    runs-on: ubuntu-latest
     needs: check-rc
     uses: ./.github/workflows/example_triggered.yml
     if: ${{ jobs.check_rc.steps.check.outputs.hasrc == 'True' }}

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -34,6 +34,6 @@ jobs:
       hasrc: ${{ steps.check.outputs.hasrc }}
 
   run_rc_tests:
-    needs: check-rc
+    needs: check_rc
     uses: ./.github/workflows/example_triggered.yml
     if: ${{ needs.check_rc.hasrc == 'True' }}

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -30,7 +30,10 @@ jobs:
           ndays: 30
           labels: 'main openmm_rc'
       - run: echo ${{ steps.check.outputs.hasrc }}
+    outputs:
+      hasrc: ${{ steps.check.outputs.hasrc }}
+
   run_rc_tests:
     needs: check-rc
     uses: ./.github/workflows/example_triggered.yml
-    if: ${{ jobs.check_rc.steps.check.outputs.hasrc == 'True' }}
+    if: ${{ needs.check_rc.hasrc == 'True' }}

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -30,8 +30,5 @@ jobs:
           ndays: 30
           labels: 'main openmm_rc'
       - run: echo ${{ steps.check.outputs.hasrc }}
-      - uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Triggered Workflow
-          token: ${{ secrets.DISPATCH_TOKEN }}
+      - uses: ./.github/workflows/example_triggered.yml@main
         if: ${{ steps.check.outputs.hasrc == 'True' }}

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -37,9 +37,9 @@ jobs:
     needs: check_rc
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ needs.check_rc.hasrc }}
+      - run: echo ${{ needs.check_rc.outputs.hasrc }}
 
   run_rc_tests:
     needs: check_rc
     uses: ./.github/workflows/example_triggered.yml
-    if: ${{ needs.check_rc.hasrc == 'True' }}
+    if: ${{ needs.check_rc.outputs.hasrc == 'True' }}

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -33,6 +33,12 @@ jobs:
     outputs:
       hasrc: ${{ steps.check.outputs.hasrc }}
 
+  check-output:
+    needs: check_rc
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ needs.check_rc.hasrc }}
+
   run_rc_tests:
     needs: check_rc
     uses: ./.github/workflows/example_triggered.yml

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -29,16 +29,13 @@ jobs:
           package: openmm
           ndays: 30
           labels: 'main openmm_rc'
+      # to use the output within the same job (different step)
       - run: echo ${{ steps.check.outputs.hasrc }}
+    # to share output between jobs, use the outputs keyword
     outputs:
       hasrc: ${{ steps.check.outputs.hasrc }}
 
-  check-output:
-    needs: check_rc
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ${{ needs.check_rc.outputs.hasrc }}
-
+  # run this job only if there's an RC
   run_rc_tests:
     needs: check_rc
     uses: ./.github/workflows/example_triggered.yml

--- a/.github/workflows/example_use.yml
+++ b/.github/workflows/example_use.yml
@@ -30,5 +30,5 @@ jobs:
           ndays: 30
           labels: 'main openmm_rc'
       - run: echo ${{ steps.check.outputs.hasrc }}
-      - uses: ./.github/workflows/example_triggered.yml@main
+      - uses: ./.github/workflows/example_triggered.yml
         if: ${{ steps.check.outputs.hasrc == 'True' }}


### PR DESCRIPTION
Looks like `benc-uk/workflow-dispatch` is failing for me everywhere, giving "bad credentials." I'm not sure if this is a GitHub change that affected required token permissions or what.

But in any case, it looks like that is no longer needed, because GitHub seems to allow you to reuse workflows now. If I can get that to work here, then we'll switch to that mode in the example.

https://docs.github.com/en/actions/using-workflows/reusing-workflows